### PR TITLE
feat(CI/CD): add initial workflow

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -37,7 +37,7 @@ jobs:
           workspaces: "backend -> target"
 
       - name: Cargo Test (workspace)
-        run: cargo test --workspace --all-targets --locked --exclude crates/desktop
+        run: cargo test --all-targets --locked
 
 
   tauri-desktop-build:

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 
 members = ["crates/desktop", "crates/promethea_core", "crates/server"]
+default-members = ["crates/promethea_core", "crates/server"]
 resolver = "2"


### PR DESCRIPTION
Added an initial workflow file that does the following each time a PR is opened:
- Run `cargo test` on the backend workspace
- Build the Tauri application (verify it builds)
- In the future, run E2E tests