### PR TITLE
39 change publication date fetching

### DIFF
--- a/backend/crates/adapters/src/metadata.rs
+++ b/backend/crates/adapters/src/metadata.rs
@@ -210,7 +210,7 @@ fn extract_amazon_book_id(
     let Some(amazon_id) = to_string(amazon_id) else {
         error!("Failed to scrape Amazon ID");
         return Err(FetchMetadataError::Extraction {
-            key: "Amazon ID".into(),
+            key: "Amazon book ID".into(),
             message: "failed to extract Amazon book ID".into(),
         });
     };
@@ -230,7 +230,7 @@ fn extract_amazon_work_id(metadata: &Value, amazon_id: &str) -> Result<String, F
     let Some(amazon_work_id) = to_string(amazon_work_id) else {
         error!("Failed to scrape Amazon ID");
         return Err(FetchMetadataError::Extraction {
-            key: "Amazon ID".into(),
+            key: "Amazon work ID".into(),
             message: "failed to extract Amazon work ID".into(),
         });
     };

--- a/backend/crates/adapters/src/metadata.rs
+++ b/backend/crates/adapters/src/metadata.rs
@@ -200,14 +200,14 @@ fn extract_amazon_book_id(
     metadata: &Value,
     goodreads_id: &GoodreadsId,
 ) -> Result<String, FetchMetadataError> {
-    let amazon_id_key = format!("getBookByLegacyId({{\"legacyId\":\"{goodreads_id}\"}})");
+    let amazon_book_id_key = format!("getBookByLegacyId({{\"legacyId\":\"{goodreads_id}\"}})");
     #[allow(
         clippy::indexing_slicing,
         reason = "`serde_json::Value` indexing never panics"
     )]
-    let amazon_id =
-        &metadata["props"]["pageProps"]["apolloState"]["ROOT_QUERY"][amazon_id_key]["__ref"];
-    let Some(amazon_id) = to_string(amazon_id) else {
+    let amazon_book_id =
+        &metadata["props"]["pageProps"]["apolloState"]["ROOT_QUERY"][amazon_book_id_key]["__ref"];
+    let Some(amazon_book_id) = to_string(amazon_book_id) else {
         error!("Failed to scrape Amazon ID");
         return Err(FetchMetadataError::Extraction {
             key: "Amazon book ID".into(),
@@ -215,18 +215,22 @@ fn extract_amazon_book_id(
         });
     };
 
-    Ok(amazon_id)
+    Ok(amazon_book_id)
 }
 
-/// Extracts a work's Amazon ID based on the book's Goodreads ID from the JSON metadata
+/// Extracts a work's Amazon ID based on the book's Amazon ID from the JSON metadata
 /// # Errors
 /// Fails if the Amazon ID cannot be extracted
-fn extract_amazon_work_id(metadata: &Value, amazon_id: &str) -> Result<String, FetchMetadataError> {
+fn extract_amazon_work_id(
+    metadata: &Value,
+    amazon_book_id: &str,
+) -> Result<String, FetchMetadataError> {
     #[allow(
         clippy::indexing_slicing,
         reason = "`serde_json::Value` indexing never panics"
     )]
-    let amazon_work_id = &metadata["props"]["pageProps"]["apolloState"][amazon_id]["work"]["__ref"];
+    let amazon_work_id =
+        &metadata["props"]["pageProps"]["apolloState"][amazon_book_id]["work"]["__ref"];
     let Some(amazon_work_id) = to_string(amazon_work_id) else {
         error!("Failed to scrape Amazon ID");
         return Err(FetchMetadataError::Extraction {
@@ -244,13 +248,13 @@ fn extract_amazon_work_id(metadata: &Value, amazon_id: &str) -> Result<String, F
 /// a subtitle.
 fn extract_title_and_subtitle(
     metadata: &Value,
-    amazon_id: &str,
+    amazon_book_id: &str,
 ) -> Result<(String, Option<String>), FetchMetadataError> {
     #[allow(
         clippy::indexing_slicing,
         reason = "`serde_json::Value` indexing never panics"
     )]
-    let title = &metadata["props"]["pageProps"]["apolloState"][amazon_id]["title"];
+    let title = &metadata["props"]["pageProps"]["apolloState"][amazon_book_id]["title"];
     let Some(title) = to_string(title) else {
         error!("Failed to scrape book title");
         return Err(FetchMetadataError::Extraction {
@@ -267,17 +271,17 @@ fn extract_title_and_subtitle(
 
 /// Extracts a book's image URL from the metadata JSON. A book may not have an image, so this
 /// function returns `Option`
-fn extract_image_url(metadata: &Value, amazon_id: &str) -> Option<String> {
+fn extract_image_url(metadata: &Value, amazon_book_id: &str) -> Option<String> {
     #[allow(
         clippy::indexing_slicing,
         reason = "`serde_json::Value` indexing never panics"
     )]
-    let url = &metadata["props"]["pageProps"]["apolloState"][amazon_id]["imageUrl"];
+    let url = &metadata["props"]["pageProps"]["apolloState"][amazon_book_id]["imageUrl"];
     to_string(url)
 }
 
 /// Extracts all contributors of a book from its metatada JSON and filters out any non-authors.
-fn extract_contributors(metadata: &Value, amazon_id: &str) -> Vec<BookContributor> {
+fn extract_contributors(metadata: &Value, amazon_book_id: &str) -> Vec<BookContributor> {
     let mut contributors = Vec::new();
 
     #[allow(
@@ -285,7 +289,7 @@ fn extract_contributors(metadata: &Value, amazon_id: &str) -> Vec<BookContributo
         reason = "`serde_json::Value` indexing never panics"
     )]
     let primary =
-        metadata["props"]["pageProps"]["apolloState"][amazon_id]["primaryContributorEdge"]
+        metadata["props"]["pageProps"]["apolloState"][amazon_book_id]["primaryContributorEdge"]
             .as_object()
             .map(|obj| (to_string(&obj["role"]), to_string(&obj["node"]["__ref"])));
 
@@ -306,7 +310,7 @@ fn extract_contributors(metadata: &Value, amazon_id: &str) -> Vec<BookContributo
         reason = "`serde_json::Value` indexing never panics"
     )]
     let Some(secondary) =
-        metadata["props"]["pageProps"]["apolloState"][amazon_id]["secondaryContributorEdges"]
+        metadata["props"]["pageProps"]["apolloState"][amazon_book_id]["secondaryContributorEdges"]
             .as_array()
     else {
         return contributors
@@ -375,14 +379,14 @@ fn fetch_contributor(metadata: &Value, (role, key): (String, String)) -> Option<
 }
 
 /// Extracts a book's publication date from its metadata JSON
-fn extract_publication_date(metadata: &Value, amazon_id: &str) -> Option<NaiveDateTime> {
+fn extract_publication_date(metadata: &Value, amazon_work_id: &str) -> Option<NaiveDateTime> {
     #[allow(
         clippy::indexing_slicing,
         reason = "`serde_json::Value` indexing never panics"
     )]
     #[allow(clippy::pattern_type_mismatch, reason = "false positive")]
     if let Value::Number(number) =
-        &metadata["props"]["pageProps"]["apolloState"][amazon_id]["details"]["publicationTime"]
+        &metadata["props"]["pageProps"]["apolloState"][amazon_work_id]["details"]["publicationTime"]
     {
         let timestamp = number.as_i64().and_then(DateTime::from_timestamp_millis);
 
@@ -397,13 +401,14 @@ fn extract_publication_date(metadata: &Value, amazon_id: &str) -> Option<NaiveDa
 }
 
 /// Extracts a book's page count from its metadata JSON
-fn extract_page_count(metadata: &Value, amazon_id: &str) -> Option<i64> {
+fn extract_page_count(metadata: &Value, amazon_book_id: &str) -> Option<i64> {
     #[allow(
         clippy::indexing_slicing,
         reason = "`serde_json::Value` indexing never panics"
     )]
     let count =
-        metadata["props"]["pageProps"]["apolloState"][amazon_id]["details"]["numPages"].as_i64();
+        metadata["props"]["pageProps"]["apolloState"][amazon_book_id]["details"]["numPages"]
+            .as_i64();
     match count {
         Some(0) => None,
         val => val,
@@ -411,14 +416,14 @@ fn extract_page_count(metadata: &Value, amazon_id: &str) -> Option<i64> {
 }
 
 /// Extracts a book's series from its metadata JSON
-fn extract_series(metadata: &Value, amazon_id: &str) -> Vec<BookSeries> {
+fn extract_series(metadata: &Value, amazon_book_id: &str) -> Vec<BookSeries> {
     let empty_vec: Vec<Value> = Vec::new();
 
     #[allow(
         clippy::indexing_slicing,
         reason = "`serde_json::Value` indexing never panics"
     )]
-    let series_array = metadata["props"]["pageProps"]["apolloState"][amazon_id]["bookSeries"]
+    let series_array = metadata["props"]["pageProps"]["apolloState"][amazon_book_id]["bookSeries"]
         .as_array()
         .unwrap_or(&empty_vec);
     #[allow(

--- a/backend/crates/adapters/src/metadata.rs
+++ b/backend/crates/adapters/src/metadata.rs
@@ -121,13 +121,15 @@ impl MetadataProviderPort for MetadataProvider {
                         message: error.to_string(),
                     })?,
             };
-        let amazon_id = extract_amazon_id(&json, &goodreads_id)?;
-        let (title, _subtitle) = extract_title_and_subtitle(&json, &amazon_id)?;
-        let image_url = extract_image_url(&json, &amazon_id);
-        let contributors = extract_contributors(&json, &amazon_id);
-        let publication_date = extract_publication_date(&json, &amazon_id);
-        let number_of_pages = extract_page_count(&json, &amazon_id);
-        let series = extract_series(&json, &amazon_id);
+        let amazon_book_id = extract_amazon_book_id(&json, &goodreads_id)?;
+        let amazon_work_id = extract_amazon_work_id(&json, &amazon_book_id)?;
+
+        let (title, _subtitle) = extract_title_and_subtitle(&json, &amazon_book_id)?;
+        let image_url = extract_image_url(&json, &amazon_book_id);
+        let contributors = extract_contributors(&json, &amazon_book_id);
+        let publication_date = extract_publication_date(&json, &amazon_work_id);
+        let number_of_pages = extract_page_count(&json, &amazon_book_id);
+        let series = extract_series(&json, &amazon_book_id);
 
         Ok(BookMetadata::new(
             &title,
@@ -194,7 +196,7 @@ fn matches(str1: &str, str2: &str) -> bool {
 /// Extracts a book's Amazon ID based on its Goodreads ID from the JSON metadata
 /// # Errors
 /// Fails if the Amazon ID cannot be extracted
-fn extract_amazon_id(
+fn extract_amazon_book_id(
     metadata: &Value,
     goodreads_id: &GoodreadsId,
 ) -> Result<String, FetchMetadataError> {
@@ -209,11 +211,31 @@ fn extract_amazon_id(
         error!("Failed to scrape Amazon ID");
         return Err(FetchMetadataError::Extraction {
             key: "Amazon ID".into(),
-            message: "failed to extract Amazon ID".into(),
+            message: "failed to extract Amazon book ID".into(),
         });
     };
 
     Ok(amazon_id)
+}
+
+/// Extracts a work's Amazon ID based on the book's Goodreads ID from the JSON metadata
+/// # Errors
+/// Fails if the Amazon ID cannot be extracted
+fn extract_amazon_work_id(metadata: &Value, amazon_id: &str) -> Result<String, FetchMetadataError> {
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "`serde_json::Value` indexing never panics"
+    )]
+    let amazon_work_id = &metadata["props"]["pageProps"]["apolloState"][amazon_id]["work"]["__ref"];
+    let Some(amazon_work_id) = to_string(amazon_work_id) else {
+        error!("Failed to scrape Amazon ID");
+        return Err(FetchMetadataError::Extraction {
+            key: "Amazon ID".into(),
+            message: "failed to extract Amazon work ID".into(),
+        });
+    };
+
+    Ok(amazon_work_id)
 }
 
 /// Extracts title and subtitle out of metadata JSON

--- a/backend/crates/adapters/src/metadata.rs
+++ b/backend/crates/adapters/src/metadata.rs
@@ -641,8 +641,8 @@ mod tests {
         assert_eq!(
             metadata.publication_date,
             Some(NaiveDateTime::new(
-                NaiveDate::from_ymd_opt(2005, 3, 1).unwrap(),
-                NaiveTime::from_hms_opt(8, 0, 0).unwrap()
+                NaiveDate::from_ymd_opt(1988, 10, 25).unwrap(),
+                NaiveTime::from_hms_opt(7, 0, 0).unwrap()
             ))
         );
         assert_eq!(


### PR DESCRIPTION
In addition to the Amazon book ID, we also extract the Amazon work ID, which is not tied to a specific version but instead to the higher-level work instead. Under that ID, we can extract the _work's_ publication date instead of the specific book format's publication date. 