### PR TITLE
fix(just): add default shell definition for nushell

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+# set the default shell to nushell
+set shell := ['nu', '-c']
+
 # run cargo tests
 test:
   cargo test --all-targets --locked --manifest-path backend/Cargo.toml


### PR DESCRIPTION
Seems like the combined behavior with `just` and `nushell` caused issues where the system couldn't figure out which shell to use and therefore tried some wrong options (originally no shell at all, after an update to `just` 1.50 it tried `sh`). Setting the default shell to be `nushell` seems to have fixed the problem.