### PR TITLE
44 refactor database opening

### DIFF
--- a/backend/crates/desktop/src/database.rs
+++ b/backend/crates/desktop/src/database.rs
@@ -5,75 +5,40 @@ use crate::state::{
 use serde_json::json;
 use shared_core::domain::repository::BookItem;
 use shared_core::usecases::books::AddBookInput;
-use std::fs::File;
 use std::path::PathBuf;
 use tauri::{AppHandle, Emitter as _, State};
 use tauri_plugin_store::StoreExt as _;
 
-/// Creates a new `SQLite` database at a given path writes the path into the Tauri store
 #[tauri::command]
-pub async fn create_new_db(
+/// Open a database connection, creating the database if it doesn't exist yet
+pub async fn open_db(
     state: State<'_, AppState>,
     app: AppHandle,
-    folder: String,
+    path_str: String,
 ) -> Result<(), PrometheaError> {
-    let db_file_path = PathBuf::from(folder).join(PathBuf::from(LIBRARY_DATABASE_NAME));
-    File::create(db_file_path.clone()).map_err(|error| {
-        PrometheaError::Other(format!("Failed to create database file: {error}"))
-    })?;
+    let mut path = PathBuf::from(path_str);
+    if path.is_dir() {
+        // path points to directory where a new file has to be created
+        path = path.join(PathBuf::from(LIBRARY_DATABASE_NAME));
+    }
 
-    // update config store
     let store = app.store(APP_CONFIG_PATH)?;
-    store.set("library-path", json!({ "value": db_file_path.to_str() }));
-    log::info!(
-        "Updated database path in store to {}",
-        db_file_path.display()
-    );
+    store.set("library-path", json!({ "value": path.to_str() }));
+    log::info!("Set database path in store to {}", path.display());
 
     {
         let mut config = state.config.write().await;
-        config.library_path = Some(db_file_path.clone());
+        config.library_path = Some(path.clone());
     }
 
-    let services = build_services(db_file_path).await?;
+    let services = build_services(path).await?;
 
     {
         let mut backend = state.backend.write().await;
         *backend = BackendState::Ready(services);
     }
 
-    Ok(())
-}
-
-/// Opens an existing database at the given path and updates the stored value in the Tauri store
-#[tauri::command]
-pub async fn open_existing_db(
-    state: State<'_, AppState>,
-    app: AppHandle,
-    path: String,
-) -> Result<(), PrometheaError> {
-    let db_file_path = PathBuf::from(path);
-
-    let store = app.store(APP_CONFIG_PATH)?;
-    store.set("library-path", json!({ "value": db_file_path.to_str() }));
-    log::info!(
-        "Updated database path in store to {}",
-        db_file_path.display()
-    );
-
-    {
-        let mut config = state.config.write().await;
-        config.library_path = Some(db_file_path.clone());
-    }
-
-    let services = build_services(db_file_path).await?;
-
-    {
-        let mut backend = state.backend.write().await;
-        *backend = BackendState::Ready(services);
-    }
-
-    // an existing DB might not be empty -> fetch books now
+    // if an existing DB was opened, it might already contain values
     app.emit("db:changed", ())?;
 
     Ok(())

--- a/backend/crates/desktop/src/lib.rs
+++ b/backend/crates/desktop/src/lib.rs
@@ -1,7 +1,7 @@
 //! `desktop`
 //!
 //! This crate contains everything Tauri-specific for promethea
-use crate::database::{add_book, create_new_db, fetch_books, get_init_status, open_existing_db};
+use crate::database::{add_book, fetch_books, get_init_status, open_db};
 use errors::PrometheaError;
 use state::{APP_CONFIG_PATH, AppState, BackendState, RuntimeConfig, build_services};
 use std::path::PathBuf;
@@ -113,11 +113,10 @@ fn run_safe() -> Result<(), PrometheaError> {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            create_new_db,
-            open_existing_db,
             get_init_status,
             fetch_books,
-            add_book
+            add_book,
+            open_db
         ])
         .run(tauri::generate_context!())?;
     Ok(())

--- a/src/features/no-database-dialog/index.tsx
+++ b/src/features/no-database-dialog/index.tsx
@@ -36,35 +36,29 @@ function useDbInitStatus() {
 export default function NoDatabaseDialog() {
   const { ready, setReady: _setReady, refresh } = useDbInitStatus();
 
-  const handleCreateNew = useCallback(async () => {
+  const handleLibrary = useCallback(async (action: string) => {
     try {
-      info("Create new button was clicked");
-      const folderPath = await dialogOpen({ multiple: false, directory: true });
-      if (!folderPath) {
-        debug("Create new cancelled by user!");
+      info(`${action} clicked`);
+      let args;
+      if (action == "CreateNew") {
+        args = { multiple: false, directory: true };
+      } else {
+        args = { multiple: false, directory: false, filters: [{ name: "library", extensions: ["db", "db3", "sqlite"] }] };
+      }
+      let pathStr = await dialogOpen(args);
+      if (!pathStr) {
+        debug("Dialog cancelled by user");
         return;
       }
-      await invoke("create_new_db", { folder: folderPath });
+      await invoke("open_db", { pathStr });
       await refresh();
-    } catch (e: any) {
-      error(`create_new_db failed: ${e?.message ?? String(e)}`);
-    }
-  }, [refresh]);
 
-  const handleOpenExisting = useCallback(async () => {
-    try {
-      info("Open existing button was clicked");
-      const filePath = await dialogOpen({ multiple: false, directory: false, filters: [{ name: "library", extensions: ["db", "db3", "sqlite"] }] });
-      if (!filePath) {
-        debug("Open existing cancelled by user!");
-        return;
-      }
-      await invoke("open_existing_db", { path: filePath });
-      await refresh();
     } catch (e: any) {
-      error(`open_existing_db failed: ${e?.message ?? String(e)}`)
+      error(`opening DB failed: ${e?.message ?? String(e)}`);
     }
-  }, [refresh]);
+  }, [refresh]
+  )
+
 
   const [open, setOpen] = useState<boolean>(true);
   useEffect(() => {
@@ -79,8 +73,8 @@ export default function NoDatabaseDialog() {
           <DialogTitle>No Database Configured Yet</DialogTitle>
           <DialogDescription>Either select an existing database file or choose a location to create a new one</DialogDescription>
           <div>
-            <Button onClick={handleCreateNew}>Create New</Button>
-            <Button onClick={handleOpenExisting}>Open Existing</Button>
+            <Button onClick={() => handleLibrary("CreateNew")}>Create New</Button>
+            <Button onClick={() => handleLibrary("OpenExisting")}>Open Existing</Button>
 
           </div>
         </DialogHeader>


### PR DESCRIPTION
Instead of having two Tauri commands that are very similar aside from file creation, `create_new_db` and `open_existing_db` have been combined into `open_db`. This command can now be used regardless of whether the database file exists or not, because the database file is now automatically being created via `SqliteConnectOptions.create_if_missing(true)`, introduced in #42 . 

The same refactoring has been done to the frontend, where previously two very similar callback functions existed for the "Create New" vs. "Open Existing" buttons. An argument is now passed to the unified `handleLibrary` callback function that defines whether the library will be newly created or not. 