### PR TITLE
fix(dialog): do not show dialog by default, only if backend requests it

### DIFF
--- a/src/features/no-database-dialog/index.tsx
+++ b/src/features/no-database-dialog/index.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useState } from "react";
 
 
 function useDbInitStatus() {
-  const [ready, setReady] = useState<boolean>(false);
+  const [ready, setReady] = useState<boolean | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -60,10 +60,16 @@ export default function NoDatabaseDialog() {
   )
 
 
-  const [open, setOpen] = useState<boolean>(true);
+  const [open, setOpen] = useState<boolean>(false);
   useEffect(() => {
-    setOpen(!ready);
+    if (ready !== null) {
+      setOpen(!ready);
+    }
   }, [ready]);
+
+  if (ready === null) {
+    return null;
+  }
 
 
   return (


### PR DESCRIPTION
The problem was that the backend asynchronously responds whether the dialog needs to be show. To fix it, the default value of the state associated with the dialog is set to `false`, meaning that we assume we don't need to show the dialog during startup. While the backend is still responding, the state is set to `null`. 

As mentioned in a comment in #46 there is still a slight flicker in the UI in cases where the library contains books already, because the table is initially displayed as empty until the backend responds with all the books. This is more of a UI styling problem and will therefore not be prioritized right now. 