### PR TITLE
feat(app): use log crate everywhere in backend

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3911,8 +3911,6 @@ dependencies = [
  "tauri-plugin-store",
  "thiserror 2.0.18",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/backend/crates/desktop/Cargo.toml
+++ b/backend/crates/desktop/Cargo.toml
@@ -36,12 +36,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0.17"
 log = { version = "0.4", features = ["max_level_info"] }
-tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.22", default-features = false, features = [
-  "fmt",
-  "env-filter",
-  "std",
-] }
 tokio = "1.52.1"
 tauri-plugin-process = "2"
 dotenvy = "0.15.7"

--- a/backend/crates/desktop/src/database.rs
+++ b/backend/crates/desktop/src/database.rs
@@ -2,6 +2,7 @@ use crate::errors::PrometheaError;
 use crate::state::{
     APP_CONFIG_PATH, AppState, BackendState, LIBRARY_DATABASE_NAME, build_services,
 };
+use log::{info, warn};
 use serde_json::json;
 use shared_core::domain::repository::BookItem;
 use shared_core::usecases::books::AddBookInput;
@@ -50,7 +51,7 @@ pub async fn get_init_status(state: State<'_, AppState>) -> Result<bool, Prometh
     let backend = state.backend.read().await;
     let config = state.config.read().await;
     if config.library_path.is_none() {
-        tracing::warn!("Database path not yet configured!");
+        warn!("Database path not yet configured!");
         Ok(false)
     } else {
         Ok(matches!(&*backend, BackendState::Ready(_)))
@@ -88,7 +89,7 @@ pub async fn add_book(
     state: State<'_, AppState>,
     path: PathBuf,
 ) -> Result<(), PrometheaError> {
-    tracing::info!("Received request to add book from {path:?}");
+    info!("Received request to add book from {}", path.display());
     let use_case = {
         let backend = state.backend.read().await;
 

--- a/backend/crates/desktop/src/lib.rs
+++ b/backend/crates/desktop/src/lib.rs
@@ -10,8 +10,6 @@ use tauri::Manager as _;
 use tauri_plugin_log::fern::colors::ColoredLevelConfig;
 use tauri_plugin_store::StoreExt as _;
 use tokio::sync::RwLock;
-#[cfg(not(debug_assertions))]
-use tracing_subscriber::{EnvFilter, fmt};
 /// Database module, holds everything dealing with accessing the database from the Tauri
 /// application
 mod database;
@@ -43,15 +41,6 @@ pub fn run() {
 /// signature of not returning anything.
 #[allow(clippy::exit, reason = "Happens in Tauri macro, cannot be avoided")]
 fn run_safe() -> Result<(), PrometheaError> {
-    #[cfg(not(debug_assertions))]
-    {
-        let subscriber = fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .finish();
-
-        tracing::subscriber::set_global_default(subscriber)
-            .expect("Unable to set global tracing subscriber");
-    }
     let enable_devtools = env::var("ENABLE_DEVTOOLS")
         .map(|val| val == "true" || val == "1")
         .unwrap_or(false);


### PR DESCRIPTION
The `tracing` crate seems less suited for my purpose. While it adds the desired functionality of simple traces printed to the console for debugging, it seems like overkill to use that crate just for this feature, especially since `log` does the same and is already required due to `tauri-plugin-log`. The latter is used anyways for logging on the frontend. All uses of `tracing` have been either fully removed or replaced with the `log` equivalents. 