### PR TITLE
57 create nixos dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 frontend/*/build
 target
+.direnv/*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ For development on Windows, install the necessary components manually, including
 
 On Unix systems, specifically NixOS, clone the repository, install `direnv` (or `nix-direnv` on NixOS), run `direnv allow` inside the repository and voilà!
 
+Note that for commit linting to work, you need to run `pnpm install` at the repository root. This installs husky, which is used to check all commit messages before allowing them through.
+
 ## Commit Signing
 This project uses signed commits with ssh. To set up:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 Due to insufficient planning beforehand, the project has been saved under the `pre-alpha` tag and then reset to an empty repository. Until planning is finished, no code will be added here.
 
+## Development
+For development on Windows, install the necessary components manually, including
+- the Rust toolchain for the backend with `cargo`, `clippy`, `rustfmt`, `rust-src` and `rust-analyzer` (as listed in [`rust-toolchain.toml`](./rust-toolchain.toml))
+- NodeJS and pnpm for the frontend
+- `just` for running recipes
+
+On Unix systems, specifically NixOS, clone the repository, install `direnv` (or `nix-direnv` on NixOS), run `direnv allow` inside the repository and voilà!
+
 ## Commit Signing
 This project uses signed commits with ssh. To set up:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ git verify-commit HEAD
 $ Good "git" signature for email@example.com with ED25519 key SHA256:<your-ssh-key>
 ```
 
+Note that you also need to register your public ssh key as a GitHub *signing* key (as opposed to a regular ssh access key). 
+
 ## Shell
 While technically not a hard requirement, the `justfile` hard-codes nushell as the shell environment. This is done because nushell is my shell of choice, and not having that option set in the `justfile` leads to problems when using `just` recipes in nushell.
 

--- a/flake.lock
+++ b/flake.lock
@@ -36,22 +36,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -62,7 +46,9 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1783663825,

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1783663825,
+        "narHash": "sha256-TTrNVoFdEw8j0Hn+shP1KAsimTmszTWBIIUliTaAuY0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "072adf9b18936c1062c48123a9b77891d5968f2c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "A basic flake with a shell";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.systems.follows = "systems";
+    };
+    rust-overlay.url = "github:oxalica/rust-overlay";
+
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }@inputs:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlays = [ (import inputs.rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            just
+            (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
+            pnpm
+            nodejs
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,10 @@
       url = "github:numtide/flake-utils";
       inputs.systems.follows = "systems";
     };
-    rust-overlay.url = "github:oxalica/rust-overlay";
-
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =


### PR DESCRIPTION
- added `.envrc` to use a nix flake for the development shell setup
- in the flake, used the Rust overlay input to load the components and versions from `rust-toolchain.toml` so it uses the same versions as non-direnv setups

Naturally, this setup requires either `direnv` or `nix-direnv` to be installed on a NixOS system