### PR TITLE
fix(dependabot): also mark top-level `package.json`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,9 @@ version: 2
 updates:
   # TypeScript / pnpm workspace
   - package-ecosystem: "npm"
-    directory: "/frontend"
+    directories: 
+      - "/frontend"
+      - "/"
 
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Previously, dependabot was set up to update dependencies for the frontend and backend specifically, i.e., in `/frontend` and `/backend`. But given that there's a top-level `package.json` due to `commitlint` and `husky` for linting git commit messages, it makes sense to add that directory as part of the `npm` ecosystem too. 