### PR TITLE
Fix ci workflows

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -20,7 +20,7 @@ jobs:
 
       # read rust-toolchain.toml file for version
       - name: Set up Rust
-        uses: action-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
 

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   clippy:
     name: clippy

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      # read rust-toolchain.toml file for version
+      - name: Set up Rust
+        uses: action-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.88.0
           components: clippy
 
       - name: Run Clippy


### PR DESCRIPTION
- fixes a warning about GitHub Actions workflow having unrestricted permissions
- fixes a silent error where the backend Clippy workflow doesn't use the same Rust version as the project itself