### PR TITLE
91 add prompt for GitHub copilot code reviews

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,0 +1,126 @@
+---
+applyTo: "**"
+excludeAgent: "cloud-agent"
+---
+
+# Code Review Guidelines
+
+## Workflow
+
+1. *Load Context*
+  - Read the `README.md` of the repository as well as that of any subdirectory, and any possible documentation files inside `/docs` (if existent) to understand the project's goals, tech stack, tools etc, testing approach etc.
+
+2. *Risk Evaluation*
+  - Categorise findings into potential bugs, security concerns and improvement suggestions.
+
+3. *Documentation Alignment*
+  - Flag missing documentation updates as a review finding.
+
+4. *Testing Gaps*
+  - Verify whether new or modified behaviour is covered by automated tests.
+  - Highlight absent tests or risky areas needing manual verification.
+
+5. Potential Errors
+  - Only state that a specific part of the code fails to build if you're 100% sure. Take existing CI/CD workflows as indicators of whether your claim could be true. 
+
+## Priorities
+
+Review changes primarily for:
+
+1. Correctness
+2. Security
+3. Maintainability
+4. Reliability
+5. Performance
+6. Test coverage
+
+Do not report purely stylistic issues that are already enforced by automated
+formatters or linters.
+
+## Correctness
+
+- Look for incorrect assumptions, edge cases, race conditions, and unexpected
+  control-flow behavior.
+- Check error paths, not only the happy path.
+- Check whether behavior changes are intentional and adequately tested.
+- Flag code where invalid or unexpected input could produce incorrect state.
+
+## Security
+
+Treat all external input as untrusted.
+
+Pay particular attention to:
+
+- authentication and authorization
+- injection vulnerabilities
+- XSS
+- unsafe URL handling
+- filesystem/path traversal
+- command execution
+- accidental exposure of secrets or sensitive information
+- insecure storage of credentials or tokens
+- missing validation at trust boundaries
+
+Do not assume that validation in a client application provides a security
+boundary.
+
+## Maintainability
+
+- Prefer simple, explicit implementations over unnecessarily clever ones.
+- Flag duplicated business logic when it could cause behavior to diverge.
+- Flag abstractions that add complexity without a clear benefit.
+- Check whether responsibilities are clearly separated.
+- Prefer code whose intent can be understood without extensive comments.
+
+Do not suggest speculative refactorings unrelated to the pull request.
+
+## Tests
+
+Request tests when a change introduces or modifies non-trivial behavior.
+
+Tests should cover:
+
+- the primary behavior
+- important edge cases
+- error cases
+- regressions fixed by the pull request
+
+## Review Findings Output Template
+
+## Potential Bug Reports
+
+- [Severity] `path/to/file`: Short headline describing the issue.
+    - Details: Explain why it is likely a bug, referencing diff context.
+    - Recommendation: Suggested fix or mitigation.
+
+## Security Considerations
+
+- [Severity] `path/to/file`: Security or privacy risk summary.
+    - Details: Reference specific lines and affected data flows.
+    - Recommendation: Steps to address or verify.
+
+## Quality Suggestions
+
+- [Severity] `path/to/file`: Improvement opportunity (performance, readability,
+  DX).
+    - Details: Observation and rationale.
+    - Recommendation: Optional refinements or follow-up tasks.
+
+## Testing & Documentation Gaps
+
+- [Severity] Area: Missing or insufficient automated tests updates.
+    - Details: What is absent and why it matters.
+    - Recommendation: Specific test cases or documentation updates to add.
+
+## Additional Guidance
+
+- Reference documentation where relevant.
+- Highlight any dependency on background jobs, cron tasks, or external services
+  that might mask live issues.
+
+## Command Usage Notes
+
+- Provide concise, actionable findings; avoid verbose summaries of obvious diff
+  content.
+- If no issues are discovered, explicitly state that no potential bugs, 
+  security concerns, or testing gaps were identified.

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -90,7 +90,7 @@ Tests should cover:
 ## Potential Bug Reports
 
 - [Severity] `path/to/file`: Short headline describing the issue.
-    - Details: Explain why it is likely a bug, referencing diff context.
+    - Details: Explain why it is likely a bug, referencing diff context. Also reference docs when you report a potential bug, be it 3rd-party docs or the specifications inside this project.
     - Recommendation: Suggested fix or mitigation.
 
 ## Security Considerations

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -1,0 +1,667 @@
+---
+applyTo: "**/*.tsx"
+excludeAgent: "cloud-agent"
+---
+
+# Code Review Guidelines
+
+## Priorities
+- Components should have focused responsibility.
+- Avoid storing derived values in state.
+- Check hook dependency arrays for stale closures and incorrect dependencies.
+- Avoid unnecessary effects when a value can be computed directly.
+- Check effects for missing cleanup.
+- Avoid unnecessary memoization unless it serves a concrete purpose.
+- Ensure list keys are stable and represent item identity.
+
+## Approach
+
+- React 19.2 First: Leverage the latest features including `<Activity>`, `useEffectEvent()`, and Performance Tracks
+- Modern Hooks: Use `use()`, `useFormStatus`, `useOptimistic`, and `useActionState` for cutting-edge patterns
+- Server Components When Beneficial: Use RSC for data fetching and reduced bundle sizes when appropriate
+- Actions for Forms: Use Actions API for form handling with progressive enhancement
+- Concurrent by Default: Leverage concurrent rendering with `startTransition` and `useDeferredValue`
+- TypeScript Throughout: Use comprehensive type safety with React 19's improved type inference
+- Performance-First: Optimize with React Compiler awareness, avoiding manual memoization when possible
+- Accessibility by Default: Build inclusive interfaces following WCAG 2.1 AA standards
+- Test-Driven: Write tests alongside components using React Testing Library best practices
+- Modern Development: Use Vite/Turbopack, ESLint, Prettier, and modern tooling for optimal DX
+
+## Guidelines
+
+- Always use functional components with hooks - class components are legacy
+- Leverage React 19.2 features: `<Activity>`, `useEffectEvent()`, `cacheSignal`, Performance Tracks
+- Use the `use()` hook for promise handling and async data fetching
+- Implement forms with Actions API and useFormStatus for loading states
+- Use `useOptimistic` for optimistic UI updates during async operations
+- Use `useActionState` for managing action state and form submissions
+- Leverage `useEffectEvent()` to extract non-reactive logic from effects (React 19.2)
+- Use `<Activity>` component to manage UI visibility and state preservation (React 19.2)
+- Use `cacheSignal` API for aborting cached fetch calls when no longer needed (React 19.2)
+- Ref as Prop (React 19): Pass `ref` directly as prop - no need for `forwardRef` anymore
+- Context without Provider (React 19): Render context directly instead of `Context.Provider`
+- Use `startTransition` for non-urgent updates to keep the UI responsive
+- Leverage Suspense boundaries for async data fetching and code splitting
+- No need to import React in every file - new JSX transform handles it
+- Use strict TypeScript with proper interface design and discriminated unions
+- Implement proper error boundaries for graceful error handling
+- Use semantic HTML elements (`<button>`, `<nav>`, `<main>`, etc.) for accessibility
+- Ensure all interactive elements are keyboard accessible
+- Optimize images with lazy loading and modern formats (WebP, AVIF)
+- Use React DevTools Performance panel with React 19.2 Performance Tracks
+- Implement code splitting with `React.lazy()` and dynamic imports
+- Use proper dependency arrays in `useEffect`, `useMemo`, and `useCallback`
+- Ref callbacks can now return cleanup functions for easier cleanup management
+
+
+## Code Examples
+
+### Using the `use()` Hook (React 19)
+
+```typescript
+import { use, Suspense } from "react";
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+async function fetchUser(id: number): Promise<User> {
+  const res = await fetch(`https://api.example.com/users/${id}`);
+  if (!res.ok) throw new Error("Failed to fetch user");
+  return res.json();
+}
+
+function UserProfile({ userPromise }: { userPromise: Promise<User> }) {
+  // use() hook suspends rendering until promise resolves
+  const user = use(userPromise);
+
+  return (
+    <div>
+      <h2>{user.name}</h2>
+      <p>{user.email}</p>
+    </div>
+  );
+}
+
+export function UserProfilePage({ userId }: { userId: number }) {
+  const userPromise = fetchUser(userId);
+
+  return (
+    <Suspense fallback={<div>Loading user...</div>}>
+      <UserProfile userPromise={userPromise} />
+    </Suspense>
+  );
+}
+```
+
+### Form with Actions and useFormStatus (React 19)
+
+```typescript
+import { useFormStatus } from "react-dom";
+import { useActionState } from "react";
+
+// Submit button that shows pending state
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button type="submit" disabled={pending}>
+      {pending ? "Submitting..." : "Submit"}
+    </button>
+  );
+}
+
+interface FormState {
+  error?: string;
+  success?: boolean;
+}
+
+// Server Action or async action
+async function createPost(prevState: FormState, formData: FormData): Promise<FormState> {
+  const title = formData.get("title") as string;
+  const content = formData.get("content") as string;
+
+  if (!title || !content) {
+    return { error: "Title and content are required" };
+  }
+
+  try {
+    const res = await fetch("https://api.example.com/posts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title, content }),
+    });
+
+    if (!res.ok) throw new Error("Failed to create post");
+
+    return { success: true };
+  } catch (error) {
+    return { error: "Failed to create post" };
+  }
+}
+
+export function CreatePostForm() {
+  const [state, formAction] = useActionState(createPost, {});
+
+  return (
+    <form action={formAction}>
+      <input name="title" placeholder="Title" required />
+      <textarea name="content" placeholder="Content" required />
+
+      {state.error && <p className="error">{state.error}</p>}
+      {state.success && <p className="success">Post created!</p>}
+
+      <SubmitButton />
+    </form>
+  );
+}
+```
+
+### Optimistic Updates with useOptimistic (React 19)
+
+```typescript
+import { useState, useOptimistic, useTransition } from "react";
+
+interface Message {
+  id: string;
+  text: string;
+  sending?: boolean;
+}
+
+async function sendMessage(text: string): Promise<Message> {
+  const res = await fetch("https://api.example.com/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  return res.json();
+}
+
+export function MessageList({ initialMessages }: { initialMessages: Message[] }) {
+  const [messages, setMessages] = useState<Message[]>(initialMessages);
+  const [optimisticMessages, addOptimisticMessage] = useOptimistic(messages, (state, newMessage: Message) => [...state, newMessage]);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSend = async (text: string) => {
+    const tempMessage: Message = {
+      id: `temp-${Date.now()}`,
+      text,
+      sending: true,
+    };
+
+    // Optimistically add message to UI
+    addOptimisticMessage(tempMessage);
+
+    startTransition(async () => {
+      const savedMessage = await sendMessage(text);
+      setMessages((prev) => [...prev, savedMessage]);
+    });
+  };
+
+  return (
+    <div>
+      {optimisticMessages.map((msg) => (
+        <div key={msg.id} className={msg.sending ? "opacity-50" : ""}>
+          {msg.text}
+        </div>
+      ))}
+      <MessageInput onSend={handleSend} disabled={isPending} />
+    </div>
+  );
+}
+```
+
+### Using useEffectEvent (React 19.2)
+
+```typescript
+import { useState, useEffect, useEffectEvent } from "react";
+
+interface ChatProps {
+  roomId: string;
+  theme: "light" | "dark";
+}
+
+export function ChatRoom({ roomId, theme }: ChatProps) {
+  const [messages, setMessages] = useState<string[]>([]);
+
+  // useEffectEvent extracts non-reactive logic from effects
+  // theme changes won't cause reconnection
+  const onMessage = useEffectEvent((message: string) => {
+    // Can access latest theme without making effect depend on it
+    console.log(`Received message in ${theme} theme:`, message);
+    setMessages((prev) => [...prev, message]);
+  });
+
+  useEffect(() => {
+    // Only reconnect when roomId changes, not when theme changes
+    const connection = createConnection(roomId);
+    connection.on("message", onMessage);
+    connection.connect();
+
+    return () => {
+      connection.disconnect();
+    };
+  }, [roomId]); // theme not in dependencies!
+
+  return (
+    <div className={theme}>
+      {messages.map((msg, i) => (
+        <div key={i}>{msg}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+### Using <Activity> Component (React 19.2)
+
+```typescript
+import { Activity, useState } from "react";
+
+export function TabPanel() {
+  const [activeTab, setActiveTab] = useState<"home" | "profile" | "settings">("home");
+
+  return (
+    <div>
+      <nav>
+        <button onClick={() => setActiveTab("home")}>Home</button>
+        <button onClick={() => setActiveTab("profile")}>Profile</button>
+        <button onClick={() => setActiveTab("settings")}>Settings</button>
+      </nav>
+
+      {/* Activity preserves UI and state when hidden */}
+      <Activity mode={activeTab === "home" ? "visible" : "hidden"}>
+        <HomeTab />
+      </Activity>
+
+      <Activity mode={activeTab === "profile" ? "visible" : "hidden"}>
+        <ProfileTab />
+      </Activity>
+
+      <Activity mode={activeTab === "settings" ? "visible" : "hidden"}>
+        <SettingsTab />
+      </Activity>
+    </div>
+  );
+}
+
+function HomeTab() {
+  // State is preserved when tab is hidden and restored when visible
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increment</button>
+    </div>
+  );
+}
+```
+
+### Custom Hook with TypeScript Generics
+
+```typescript
+import { useState, useEffect } from "react";
+
+interface UseFetchResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useFetch<T>(url: string): UseFetchResult<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [refetchCounter, setRefetchCounter] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+
+        const json = await response.json();
+
+        if (!cancelled) {
+          setData(json);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error("Unknown error"));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url, refetchCounter]);
+
+  const refetch = () => setRefetchCounter((prev) => prev + 1);
+
+  return { data, loading, error, refetch };
+}
+
+// Usage with type inference
+function UserList() {
+  const { data, loading, error } = useFetch<User[]>("https://api.example.com/users");
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
+
+  return (
+    <ul>
+      {data.map((user) => (
+        <li key={user.id}>{user.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+### Error Boundary with TypeScript
+
+```typescript
+import { Component, ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Error caught by boundary:", error, errorInfo);
+    // Log to error reporting service
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <div role="alert">
+            <h2>Something went wrong</h2>
+            <details>
+              <summary>Error details</summary>
+              <pre>{this.state.error?.message}</pre>
+            </details>
+            <button onClick={() => this.setState({ hasError: false, error: null })}>Try again</button>
+          </div>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}
+```
+
+### Using cacheSignal for Resource Cleanup (React 19.2)
+
+```typescript
+import { cache, cacheSignal } from "react";
+
+// Cache with automatic cleanup when cache expires
+const fetchUserData = cache(async (userId: string) => {
+  const controller = new AbortController();
+  const signal = cacheSignal();
+
+  // Listen for cache expiration to abort the fetch
+  signal.addEventListener("abort", () => {
+    console.log(`Cache expired for user ${userId}`);
+    controller.abort();
+  });
+
+  try {
+    const response = await fetch(`https://api.example.com/users/${userId}`, {
+      signal: controller.signal,
+    });
+
+    if (!response.ok) throw new Error("Failed to fetch user");
+    return await response.json();
+  } catch (error) {
+    if (error.name === "AbortError") {
+      console.log("Fetch aborted due to cache expiration");
+    }
+    throw error;
+  }
+});
+
+// Usage in component
+function UserProfile({ userId }: { userId: string }) {
+  const user = use(fetchUserData(userId));
+
+  return (
+    <div>
+      <h2>{user.name}</h2>
+      <p>{user.email}</p>
+    </div>
+  );
+}
+```
+
+### Ref as Prop - No More forwardRef (React 19)
+
+```typescript
+// React 19: ref is now a regular prop!
+interface InputProps {
+  placeholder?: string;
+  ref?: React.Ref<HTMLInputElement>; // ref is just a prop now
+}
+
+// No need for forwardRef anymore
+function CustomInput({ placeholder, ref }: InputProps) {
+  return <input ref={ref} placeholder={placeholder} className="custom-input" />;
+}
+
+// Usage
+function ParentComponent() {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const focusInput = () => {
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div>
+      <CustomInput ref={inputRef} placeholder="Enter text" />
+      <button onClick={focusInput}>Focus Input</button>
+    </div>
+  );
+}
+```
+
+### Context Without Provider (React 19)
+
+```typescript
+import { createContext, useContext, useState } from "react";
+
+interface ThemeContextType {
+  theme: "light" | "dark";
+  toggleTheme: () => void;
+}
+
+// Create context
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+// React 19: Render context directly instead of Context.Provider
+function App() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+  };
+
+  const value = { theme, toggleTheme };
+
+  // Old way: <ThemeContext.Provider value={value}>
+  // New way in React 19: Render context directly
+  return (
+    <ThemeContext value={value}>
+      <Header />
+      <Main />
+      <Footer />
+    </ThemeContext>
+  );
+}
+
+// Usage remains the same
+function Header() {
+  const { theme, toggleTheme } = useContext(ThemeContext)!;
+
+  return (
+    <header className={theme}>
+      <button onClick={toggleTheme}>Toggle Theme</button>
+    </header>
+  );
+}
+```
+
+### Ref Callback with Cleanup Function (React 19)
+
+```typescript
+import { useState } from "react";
+
+function VideoPlayer() {
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  // React 19: Ref callbacks can now return cleanup functions!
+  const videoRef = (element: HTMLVideoElement | null) => {
+    if (element) {
+      console.log("Video element mounted");
+
+      // Set up observers, listeners, etc.
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            element.play();
+          } else {
+            element.pause();
+          }
+        });
+      });
+
+      observer.observe(element);
+
+      // Return cleanup function - called when element is removed
+      return () => {
+        console.log("Video element unmounting - cleaning up");
+        observer.disconnect();
+        element.pause();
+      };
+    }
+  };
+
+  return (
+    <div>
+      <video ref={videoRef} src="/video.mp4" controls />
+      <button onClick={() => setIsPlaying(!isPlaying)}>{isPlaying ? "Pause" : "Play"}</button>
+    </div>
+  );
+}
+```
+
+### Document Metadata in Components (React 19)
+
+```typescript
+// React 19: Place metadata directly in components
+// React will automatically hoist these to <head>
+function BlogPost({ post }: { post: Post }) {
+  return (
+    <article>
+      {/* These will be hoisted to <head> */}
+      <title>{post.title} - My Blog</title>
+      <meta name="description" content={post.excerpt} />
+      <meta property="og:title" content={post.title} />
+      <meta property="og:description" content={post.excerpt} />
+      <link rel="canonical" href={`https://myblog.com/posts/${post.slug}`} />
+
+      {/* Regular content */}
+      <h1>{post.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: post.content }} />
+    </article>
+  );
+}
+```
+
+### useDeferredValue with Initial Value (React 19)
+
+```typescript
+import { useState, useDeferredValue, useTransition } from "react";
+
+interface SearchResultsProps {
+  query: string;
+}
+
+function SearchResults({ query }: SearchResultsProps) {
+  // React 19: useDeferredValue now supports initial value
+  // Shows "Loading..." initially while first deferred value loads
+  const deferredQuery = useDeferredValue(query, "Loading...");
+
+  const results = useSearchResults(deferredQuery);
+
+  return (
+    <div>
+      <h3>Results for: {deferredQuery}</h3>
+      {deferredQuery === "Loading..." ? (
+        <p>Preparing search...</p>
+      ) : (
+        <ul>
+          {results.map((result) => (
+            <li key={result.id}>{result.title}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function SearchApp() {
+  const [query, setQuery] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const handleSearch = (value: string) => {
+    startTransition(() => {
+      setQuery(value);
+    });
+  };
+
+  return (
+    <div>
+      <input type="search" onChange={(e) => handleSearch(e.target.value)} placeholder="Search..." />
+      {isPending && <span>Searching...</span>}
+      <SearchResults query={query} />
+    </div>
+  );
+}
+```

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -382,7 +382,6 @@ Advise on performance:
    }
    ```
 
-## Deployment Guidance
 
 ## Communication Style
 

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -25,7 +25,7 @@ Help developers implement tools using macros:
 ```rust
 use rmcp::tool;
 use rmcp::model::Parameters;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize};
 use schemars::JsonSchema;
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -1,0 +1,405 @@
+---
+applyTo: "**/*.rs"
+excludeAgent: "cloud-agent"
+---
+
+# Code Review Guidelines
+
+
+## Your Expertise
+
+- **Async Rust**: Tokio runtime, async/await patterns, futures
+- **Type Safety**: Serde, JsonSchema, type-safe parameter validation
+- **Transports**: Stdio, HTTP
+- **Error Handling**: ErrorData, `thiserror`, proper error propagation
+- **Testing**: Unit tests, integration tests, tokio-test
+- **Performance**: Arc, RwLock, efficient state management
+- **Deployment**: Cross-compilation, binary distribution
+
+## Common Tasks
+
+### Tool Implementation
+
+Help developers implement tools using macros:
+
+```rust
+use rmcp::tool;
+use rmcp::model::Parameters;
+use serde::{Deserialize, Serialize};
+use schemars::JsonSchema;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CalculateParams {
+    pub a: f64,
+    pub b: f64,
+    pub operation: String,
+}
+
+#[tool(
+    name = "calculate",
+    description = "Performs arithmetic operations",
+    annotations(read_only_hint = true, idempotent_hint = true)
+)]
+pub async fn calculate(params: Parameters<CalculateParams>) -> Result<f64, String> {
+    let p = params.inner();
+    match p.operation.as_str() {
+        "add" => Ok(p.a + p.b),
+        "subtract" => Ok(p.a - p.b),
+        "multiply" => Ok(p.a * p.b),
+        "divide" if p.b != 0.0 => Ok(p.a / p.b),
+        "divide" => Err("Division by zero".to_string()),
+        _ => Err(format!("Unknown operation: {}", p.operation)),
+    }
+}
+```
+
+### Server Handler with Macros
+
+Guide developers in using tool router macros:
+
+```rust
+use rmcp::{tool_router, tool_handler};
+use rmcp::server::{ServerHandler, ToolRouter};
+
+pub struct MyHandler {
+    state: ServerState,
+    tool_router: ToolRouter,
+}
+
+#[tool_router]
+impl MyHandler {
+    #[tool(name = "greet", description = "Greets a user")]
+    async fn greet(params: Parameters<GreetParams>) -> String {
+        format!("Hello, {}!", params.inner().name)
+    }
+
+    #[tool(name = "increment", annotations(destructive_hint = true))]
+    async fn increment(state: &ServerState) -> i32 {
+        state.increment().await
+    }
+
+    pub fn new() -> Self {
+        Self {
+            state: ServerState::new(),
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for MyHandler {
+    // Prompt and resource handlers...
+}
+```
+
+### Transport Configuration
+
+Assist with different transport setups:
+
+**Stdio (for CLI integration):**
+
+```rust
+use rmcp::transport::StdioTransport;
+
+let transport = StdioTransport::new();
+let server = Server::builder()
+    .with_handler(handler)
+    .build(transport)?;
+server.run(signal::ctrl_c()).await?;
+```
+
+**SSE (Server-Sent Events):**
+
+```rust
+use rmcp::transport::SseServerTransport;
+use std::net::SocketAddr;
+
+let addr: SocketAddr = "127.0.0.1:8000".parse()?;
+let transport = SseServerTransport::new(addr);
+let server = Server::builder()
+    .with_handler(handler)
+    .build(transport)?;
+server.run(signal::ctrl_c()).await?;
+```
+
+**HTTP with Axum:**
+
+```rust
+use rmcp::transport::StreamableHttpTransport;
+use axum::{Router, routing::post};
+
+let transport = StreamableHttpTransport::new();
+let app = Router::new()
+    .route("/mcp", post(transport.handler()));
+
+let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+axum::serve(listener, app).await?;
+```
+
+### Prompt Implementation
+
+Guide prompt handler implementation:
+
+```rust
+async fn list_prompts(
+    &self,
+    _request: Option<PaginatedRequestParam>,
+    _context: RequestContext<RoleServer>,
+) -> Result<ListPromptsResult, ErrorData> {
+    let prompts = vec![
+        Prompt {
+            name: "code-review".to_string(),
+            description: Some("Review code for best practices".to_string()),
+            arguments: Some(vec![
+                PromptArgument {
+                    name: "language".to_string(),
+                    description: Some("Programming language".to_string()),
+                    required: Some(true),
+                },
+                PromptArgument {
+                    name: "code".to_string(),
+                    description: Some("Code to review".to_string()),
+                    required: Some(true),
+                },
+            ]),
+        },
+    ];
+    Ok(ListPromptsResult { prompts })
+}
+
+async fn get_prompt(
+    &self,
+    request: GetPromptRequestParam,
+    _context: RequestContext<RoleServer>,
+) -> Result<GetPromptResult, ErrorData> {
+    match request.name.as_str() {
+        "code-review" => {
+            let args = request.arguments.as_ref()
+                .ok_or_else(|| ErrorData::invalid_params("arguments required"))?;
+
+            let language = args.get("language")
+                .ok_or_else(|| ErrorData::invalid_params("language required"))?;
+            let code = args.get("code")
+                .ok_or_else(|| ErrorData::invalid_params("code required"))?;
+
+            Ok(GetPromptResult {
+                description: Some(format!("Code review for {}", language)),
+                messages: vec![
+                    PromptMessage::user(format!(
+                        "Review this {} code for best practices:\n\n{}",
+                        language, code
+                    )),
+                ],
+            })
+        }
+        _ => Err(ErrorData::invalid_params("Unknown prompt")),
+    }
+}
+```
+
+### Resource Implementation
+
+Help with resource handlers:
+
+```rust
+async fn list_resources(
+    &self,
+    _request: Option<PaginatedRequestParam>,
+    _context: RequestContext<RoleServer>,
+) -> Result<ListResourcesResult, ErrorData> {
+    let resources = vec![
+        Resource {
+            uri: "file:///config/settings.json".to_string(),
+            name: "Server Settings".to_string(),
+            description: Some("Server configuration".to_string()),
+            mime_type: Some("application/json".to_string()),
+        },
+    ];
+    Ok(ListResourcesResult { resources })
+}
+
+async fn read_resource(
+    &self,
+    request: ReadResourceRequestParam,
+    _context: RequestContext<RoleServer>,
+) -> Result<ReadResourceResult, ErrorData> {
+    match request.uri.as_str() {
+        "file:///config/settings.json" => {
+            let settings = self.load_settings().await
+                .map_err(|e| ErrorData::internal_error(e.to_string()))?;
+
+            let json = serde_json::to_string_pretty(&settings)
+                .map_err(|e| ErrorData::internal_error(e.to_string()))?;
+
+            Ok(ReadResourceResult {
+                contents: vec![
+                    ResourceContents::text(json)
+                        .with_uri(request.uri)
+                        .with_mime_type("application/json"),
+                ],
+            })
+        }
+        _ => Err(ErrorData::invalid_params("Unknown resource")),
+    }
+}
+```
+
+### State Management
+
+Advise on shared state patterns:
+
+```rust
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use std::collections::HashMap;
+
+#[derive(Clone)]
+pub struct ServerState {
+    counter: Arc<RwLock<i32>>,
+    cache: Arc<RwLock<HashMap<String, String>>>,
+}
+
+impl ServerState {
+    pub fn new() -> Self {
+        Self {
+            counter: Arc::new(RwLock::new(0)),
+            cache: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn increment(&self) -> i32 {
+        let mut counter = self.counter.write().await;
+        *counter += 1;
+        *counter
+    }
+
+    pub async fn set_cache(&self, key: String, value: String) {
+        let mut cache = self.cache.write().await;
+        cache.insert(key, value);
+    }
+
+    pub async fn get_cache(&self, key: &str) -> Option<String> {
+        let cache = self.cache.read().await;
+        cache.get(key).cloned()
+    }
+}
+```
+
+### Error Handling
+
+Guide proper error handling:
+
+```rust
+// Application-level errors with thiserror
+async fn load_data() -> Result<Data, Error> {
+    let content = tokio::fs::read_to_string("data.json")
+        .await?;
+
+    let data: Data = serde_json::from_str(&content)?;
+
+    Ok(data)
+}
+
+#[derive(thiserror::Error, Debug)]
+enum LoadDataError {
+  #[error("failed to open JSON file")]
+  Open(#[from] io::Error),
+  #[error("failed to parse JSON")]
+  Parse(#[from] serde_json::Error)
+}
+```
+
+### Testing
+
+Provide testing guidance:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::Parameters;
+
+    #[tokio::test]
+    async fn test_calculate_add() {
+        let params = Parameters::new(CalculateParams {
+            a: 5.0,
+            b: 3.0,
+            operation: "add".to_string(),
+        });
+
+        let result = calculate(params).await.unwrap();
+        assert_eq!(result, 8.0);
+    }
+
+    #[tokio::test]
+    async fn test_server_handler() {
+        let handler = MyHandler::new();
+        let context = RequestContext::default();
+
+        let result = handler.list_tools(None, context).await.unwrap();
+        assert!(!result.tools.is_empty());
+    }
+}
+```
+
+### Performance Optimization
+
+Advise on performance:
+
+1. **Use appropriate lock types:**
+
+   - `RwLock` for read-heavy workloads
+   - `Mutex` for write-heavy workloads
+   - Consider `DashMap` for concurrent hash maps
+
+2. **Minimize lock duration:**
+
+   ```rust
+   // Good: Clone data out of lock
+   let value = {
+       let data = self.data.read().await;
+       data.clone()
+   };
+   process(value).await;
+
+   // Bad: Hold lock during async operation
+   let data = self.data.read().await;
+   process(&*data).await; // Lock held too long
+   ```
+
+3. **Use buffered channels:**
+
+   ```rust
+   use tokio::sync::mpsc;
+   let (tx, rx) = mpsc::channel(100); // Buffered
+   ```
+
+4. **Batch operations:**
+   ```rust
+   async fn batch_process(&self, items: Vec<Item>) -> Vec<Result<(), Error>> {
+       use futures::future::join_all;
+       join_all(items.into_iter().map(|item| self.process(item))).await
+   }
+   ```
+
+## Deployment Guidance
+
+## Communication Style
+
+- Explain Rust-specific patterns (ownership, lifetimes, async)
+- Include error handling in all examples
+- Suggest performance optimizations when relevant
+- Help debug compilation errors and async issues
+- Recommend testing strategies
+- Guide on proper macro usage
+
+## Key Principles
+
+1. **Type Safety First**: Use JsonSchema for all parameters
+2. **Async All The Way**: All handlers must be async
+3. **Proper Error Handling**: Use Result types and ErrorData
+4. **Test Coverage**: Unit tests for tools, integration tests for handlers
+5. **Documentation**: Doc comments on all public items
+6. **Performance**: Consider concurrency and lock contention
+7. **Idiomatic Rust**: Follow Rust conventions and best practices
+8. **Correct Versions**: Follow each crate's specific version for the docs

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/*.ts, **/*.tsx"
+applyTo: **/*.{ts, tsx}
 ---
 # TypeScript Coding Standards
 This file defines our TypeScript coding conventions for Copilot code review.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,56 @@
+---
+applyTo: "**/*.ts, **/*.tsx"
+---
+# TypeScript Coding Standards
+This file defines our TypeScript coding conventions for Copilot code review.
+
+## Naming Conventions
+
+- Use `camelCase` for variables and functions.
+- Use `PascalCase` for class and interface names.
+- Prefix private variables with `_`.
+- Use descriptive names.
+
+## Code Style
+
+- Prefer `const` over `let` when variables are not reassigned.
+- Use arrow functions for anonymous callbacks.
+- Avoid using `any` type; specify more precise types whenever possible.
+
+## Error Handling
+
+- Always handle promise rejections with `try/catch` or `.catch()`.
+- Use custom error classes for application-specific errors.
+
+## Testing
+
+- Write unit tests for all exported functions.
+- Use [Jest](https://jestjs.io/) for all testing.
+- Name test files as `<filename>.test.ts`.
+
+## Example
+
+```typescript
+// Good
+interface User {
+  id: number;
+  name: string;
+}
+
+const fetchUser = async (id: number): Promise<User> => {
+  try {
+    // ...fetch logic
+  } catch (error) {
+    // handle error
+  }
+};
+
+// Bad
+interface user {
+  Id: number;
+  Name: string;
+}
+
+async function FetchUser(Id) {
+  // ...fetch logic, no error handling
+}

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -55,3 +55,4 @@ interface user {
 async function FetchUser(Id) {
   // ...fetch logic, no error handling
 }
+```

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -26,8 +26,8 @@ This file defines our TypeScript coding conventions for Copilot code review.
 ## Testing
 
 - Write unit tests for all exported functions.
-- Use [Jest](https://jestjs.io/) for all testing.
-- Name test files as `<filename>.test.ts`.
+- Use [Vitest](https://vitest.dev/) for all testing.
+- Name test files as `<filename>.spec.ts` (or `<filename>.spec.tsx` for React components).
 
 ## Example
 

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: **/*.{ts, tsx}
+applyTo: **/*.{ts,tsx}
 excludeAgent: "cloud-agent"
 ---
 # TypeScript Coding Standards

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,5 +1,6 @@
 ---
 applyTo: **/*.{ts, tsx}
+excludeAgent: "cloud-agent"
 ---
 # TypeScript Coding Standards
 This file defines our TypeScript coding conventions for Copilot code review.


### PR DESCRIPTION
Several prompts for GitHub Copilot's code reviews have been added:
- `.github/instructions/code-review.instructions.md`: general instructions applicable regardless of which part/language is contained in the change
- `.github/instructions/rust.instructions.md`: language-specific instructions for the Rust backend, including specific crates for error handling and HTTP server implementation
- `.github/instructions/typescript.instructions.md`: language-specific instructions for the TypeScript frontend
- `.github/instructions/react.instructions.md`: framework-specific instructions for the React frontend framework